### PR TITLE
chore: update setup-python to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,11 +35,10 @@ inputs:
     required: false
     default: "1.1.13"
 
-
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -47,12 +46,12 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-  
+
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
         version: ${{ inputs.poetry-version }}
-    
+
     - name: Authenticate to CodeArtifact
       uses: source-ag/codeartifact-login-action@main
       with:
@@ -64,7 +63,7 @@ runs:
         codeartifact-domain-owner: ${{ inputs.codeartifact-domain-owner }}
         codeartifact-repository: ${{ inputs.codeartifact-repository }}
         configure-poetry: true
-  
+
     - name: Publish
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
This should get rid of deprecation warnings
