### PR TITLE
feat: allow skipping checkout when publishing a package

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: which Poetry version to use
     required: false
     default: "1.3.2"
+  skip-checkout:
+    description: if code checkout should be skipped. Useful if you already do a code checkout earlier in your workflow
+    required: false
+    default: "false" # warning: composite actions only allow strings as input!
 
 runs:
   using: "composite"
@@ -44,6 +48,7 @@ runs:
 
     - name: Check out
       uses: actions/checkout@v3
+      if: ${{ inputs.skip-checkout == "false" }}
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
This allows us to use this action in places where the code has already been checked out and subsequently modified